### PR TITLE
Add OTEL, Loki, Promtail and fix observability stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 data/
-
+*.pyc
+__pycache__/
+db.sqlite3
+.env

--- a/README.md
+++ b/README.md
@@ -1,98 +1,74 @@
-# Observability-For-DevOps
+# Observability Stack for DevOps
 
-This repository provides a comprehensive observability stack tailored for DevOps engineers. It integrates key tools like Prometheus, Grafana, cAdvisor, and Node Exporter to monitor, visualize, and manage your infrastructure and applications. Additionally, it includes a custom Notes App to demonstrate the observability stack in action.
+Metrics, logs, and traces — one `docker compose up` away.
 
 ![Docker + cAdvisor Stack](assets/docker.png)
 ![NodeExporter Stack](assets/nodeexporter.png)
 
-## Table of Contents
-- [Overview](#overview)
-- [Tech Stack](#tech-stack)
-- [Features](#features)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Services](#services)
-- [Volumes](#volumes)
-- [Network](#network)
-- [Monitoring Setup](#monitoring-setup)
-- [Contributing](#contributing)
-- [License](#license)
+## What's in the box
 
-## Overview
-In modern DevOps, observability is key to ensuring the health and performance of your applications and infrastructure. This repository sets up an observability stack that includes metrics collection, container monitoring, and real-time visualization.
+```
+Prometheus  ← scrapes ← Node Exporter, cAdvisor, OTEL Collector
+Loki        ← pushes  ← Promtail (container logs)
+OTEL        ← OTLP    → exports metrics to Prometheus
+Grafana     → queries  → Prometheus + Loki (auto-provisioned)
+Notes App   → demo workload
+```
 
-## Tech Stack
-- **Docker & Docker Compose**: Containerization and orchestration.
-- **Prometheus**: Metrics collection and monitoring.
-- **Grafana**: Data visualization and dashboard creation.
-- **cAdvisor**: Container resource monitoring.
-- **Node Exporter**: Hardware and OS metrics exporter.
-- **Notes App**: A custom service to demonstrate monitoring.
+## Quick start
 
-## Features
-- Real-time monitoring of container metrics with Prometheus.
-- Visualize metrics using Grafana dashboards.
-- Monitor hardware, OS metrics, and custom application performance.
-- Easily extendable for additional services and metrics.
-- Persistent data storage for Prometheus and Grafana.
+```bash
+git clone https://github.com/yourusername/Observability-For-DevOps.git
+cd Observability-For-DevOps
+docker compose up -d
+```
 
-## Installation
+That's it. Open http://localhost:3000 (admin/admin).
 
-1. **Clone the repository**:
-    ```bash
-    git clone https://github.com/yourusername/Observability-For-DevOps.git
-    cd Observability-For-DevOps
-    ```
+## Endpoints
 
-2. **Ensure Docker and Docker Compose are installed**:
-    - [Docker Installation Guide](https://docs.docker.com/get-docker/)
-    - [Docker Compose Installation Guide](https://docs.docker.com/compose/install/)
+| Service | URL | What it does |
+|---------|-----|--------------|
+| Grafana | [:3000](http://localhost:3000) | Dashboards for metrics + logs |
+| Prometheus | [:9090](http://localhost:9090) | Metrics store, check `/targets` |
+| Loki | [:3100](http://localhost:3100) | Log aggregation backend |
+| cAdvisor | [:8080](http://localhost:8080) | Container resource metrics |
+| OTEL Collector | `:4317` gRPC / `:4318` HTTP | Send OTLP traces, metrics, logs |
+| Notes App | [:8000](http://localhost:8000) | Sample Django app |
 
-3. **Download Prometheus config file**:
-    ```bash
-    wget https://raw.githubusercontent.com/prometheus/prometheus/main/documentation/examples/prometheus.yml
-    ```
-    
-4. **Run the stack**:
-    ```bash
-    docker compose up -d
-    ```
+Node Exporter and Promtail run internally (no exposed ports needed).
 
-## Usage
+## Sending traces to OTEL
 
-- Access **Grafana** at `http://localhost:3000`
-  - Default credentials: `admin` / `admin` (you'll be prompted to change this)
-- Access **Prometheus** at `http://localhost:9090`
-- Access **cAdvisor** at `http://localhost:8080`
-- **Node Exporter** metrics will be available at `http://localhost:9100/metrics`
-- Access **Notes App** at `http://localhost:8000`
+The collector accepts OTLP on ports 4317 (gRPC) and 4318 (HTTP). Point your instrumented app at it:
 
-## Services
+```bash
+# quick test
+curl -X POST http://localhost:4318/v1/traces \
+  -H 'Content-Type: application/json' \
+  -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my-app"}}]},"scopeSpans":[{"spans":[{"traceId":"aaaabbbbccccddddaaaabbbbccccdddd","spanId":"aaaabbbbccccdddd","name":"test","kind":1,"startTimeUnixNano":"1000000000","endTimeUnixNano":"2000000000","status":{}}]}]}]}'
+```
 
-- **Grafana**: Visualization tool for Prometheus data.
-- **Prometheus**: Collects and stores metrics.
-- **Node Exporter**: Exports hardware and OS-level metrics.
-- **cAdvisor**: Provides container resource usage and performance metrics.
-- **Notes App**: Sample application to demonstrate monitoring.
+Metrics from OTLP get exported to Prometheus. Traces go to debug logs (swap in Jaeger/Tempo when ready).
 
-## Volumes
+## Project structure
 
-- `prometheus_data`: Stores Prometheus data persistently.
-- `grafana_data`: Stores Grafana dashboards and data persistently.
+```
+.
+├── docker-compose.yml
+├── prometheus.yml                          # scrape config
+├── otel-collector/otel-collector-config.yml
+├── loki/loki-config.yml
+├── promtail/promtail-config.yml
+├── grafana/provisioning/
+│   ├── datasources/datasources.yml         # Prometheus + Loki
+│   └── dashboards/dashboards.yml           # drop JSON files in dashboards/json/
+└── notes-app/                              # Django demo app
+```
 
-## Network
+## Tear down
 
-- **monitoring**: Custom bridge network to ensure isolation and communication between services.
-
-## Monitoring Setup
-
-- **Grafana Dashboards**: Pre-configured to visualize data from Prometheus.
-- **Prometheus Configuration**: Configured to scrape metrics from Node Exporter, cAdvisor, and Notes App.
-
-## Contributing
-
-Contributions are welcome! Please submit a pull request or open an issue for any changes or improvements.
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+```bash
+docker compose down          # stop everything
+docker compose down -v       # stop + delete all data
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 networks:
   monitoring:
     driver: bridge
@@ -7,6 +5,7 @@ networks:
 volumes:
   prometheus_data: {}
   grafana_data: {}
+  loki_data: {}
 
 services:
   grafana:
@@ -16,8 +15,8 @@ services:
       - "3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./data/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
-      - ./data/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     networks:
       - monitoring
     restart: unless-stopped
@@ -59,9 +58,51 @@ services:
       - "8080:8080"
     volumes:
       - /:/rootfs:ro
-      - /var/run:/var/run:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - monitoring
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/config.yaml
+    networks:
+      - monitoring
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/config.yaml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yaml
+    depends_on:
+      - loki
+    networks:
+      - monitoring
+    restart: unless-stopped
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector/otel-collector-config.yml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    expose:
+      - 8889
     networks:
       - monitoring
     restart: unless-stopped
@@ -74,9 +115,6 @@ services:
     container_name: notes-app
     ports:
       - "8000:8000"
-    volumes:
-      - ./notes-app:/app
     networks:
       - monitoring
-    restart: always
-
+    restart: unless-stopped

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    folder: ""
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/grafana/provisioning/datasources/datasources.yml
+++ b/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/loki/loki-config.yml
+++ b/loki/loki-config.yml
@@ -1,0 +1,26 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+    - from: "2020-10-24"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks

--- a/otel-collector/otel-collector-config.yml
+++ b/otel-collector/otel-collector-config.yml
@@ -1,0 +1,31 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,38 +1,20 @@
-# my global config
 global:
-  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
+  scrape_interval: 15s
+  evaluation_interval: 15s
 
-# Alertmanager configuration
-alerting:
-  alertmanagers:
-    - static_configs:
-        - targets:
-          # - alertmanager:9093
-
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: "prometheus"
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
     static_configs:
       - targets: ["localhost:9090"]
 
-
-  - job_name: "Docker"
+  - job_name: "docker"
     static_configs:
       - targets: ["cadvisor:8080"]
 
-  - job_name: "NodeExporter"
+  - job_name: "node-exporter"
     static_configs:
       - targets: ["node-exporter:9100"]
+
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/promtail/promtail-config.yml
+++ b/promtail/promtail-config.yml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          __path__: /var/lib/docker/containers/*/*-json.log
+    pipeline_stages:
+      - docker: {}


### PR DESCRIPTION
- Add OpenTelemetry Collector with OTLP receivers and Prometheus exporter
- Add Loki + Promtail for container log aggregation
- Add Grafana provisioning for Prometheus and Loki datasources
- Fix Grafana volume paths, cAdvisor docker socket mount
- Clean up prometheus.yml, remove dead config and comments
- Add otel-collector scrape target to Prometheus
- Remove deprecated docker-compose version field
- Update .gitignore and README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added log aggregation and trace collection to the monitoring stack
  * Integrated OpenTelemetry support for comprehensive observability (metrics, logs, traces)
  * New endpoints available for log querying and trace ingestion

* **Documentation**
  * Simplified project setup guide with quick-start instructions and service endpoints reference

* **Chores**
  * Updated project configuration and deployment structure for improved organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->